### PR TITLE
Knockback Changes

### DIFF
--- a/PvPModifier/Config.cs
+++ b/PvPModifier/Config.cs
@@ -30,6 +30,13 @@ namespace PvPModifier {
 
         public bool FirstConfigGeneration { get; set; } = true;
 
+        public double KnockbackMultiplier { get; set; }
+        public double KnockupAmount { get; set; }
+        public double KnockbackFalloff { get; set; }
+        public double MaxKnockbackSpeed { get; set; }
+        public uint ComboTime { get; set; }
+        
+
         /// <summary>
         /// Writes the current internal server config to the external .json file
         /// </summary>
@@ -74,6 +81,14 @@ namespace PvPModifier {
                 EnableBuffs = true;
 
                 FirstConfigGeneration = false;
+
+                KnockbackMultiplier = 1.0;
+                KnockupAmount = 1.0;
+                KnockbackFalloff = 0.5;
+                MaxKnockbackSpeed = 30;
+                ComboTime = 500;
+               
+
                 return true;
             }
 

--- a/PvPModifier/Network/PvPEvents.cs
+++ b/PvPModifier/Network/PvPEvents.cs
@@ -208,17 +208,25 @@ namespace PvPModifier.Network {
         /// Handles pvp attacks.
         /// </summary>
         private void OnPlayerHurt(object sender, PlayerHurtArgs e) {
-            if (!PvPModifier.Config.EnablePlugin) return;
-
+            if (!PvPModifier.Config.EnablePlugin) return;          
             e.Args.Handled = true;
-
+           
             if (e.Attacker.TPlayer.immune || !e.Target.CanBeHit()) return;
 
             if (PvPModifier.Config.EnableKnockback) {
                 int direction = e.HitDirection;
+                double angle;
+                if (e.PlayerHitReason.SourceProjectileIndex != -1) {
+                    angle = Math.Atan2(e.Projectile.velocity.Y, e.Projectile.velocity.X);
+                    direction = e.Target.IsLeftFrom(e.Projectile.position) ? -direction : direction;
+                }
+                else { 
+                    angle = e.Attacker.AngleFrom(e.Target.TPlayer.position);
+                    direction = e.Target.IsLeftFrom(e.Attacker.TPlayer.position) ? -direction : direction;
+                }
                 e.Target.KnockBack(e.Weapon.GetKnockback(e.Attacker),
-                    e.Attacker.AngleFrom(e.Target.TPlayer.position),
-                    e.Target.IsLeftFrom(e.Attacker.TPlayer.position) ? -direction : direction);
+                   angle,
+                   direction);
                 e.HitDirection = 0;
             }
             

--- a/PvPModifier/Utilities/PvPConstants/ConfigConsts.cs
+++ b/PvPModifier/Utilities/PvPConstants/ConfigConsts.cs
@@ -26,5 +26,13 @@
         public const string FrostDuration = "FrostDuration";
 
         public const string EnableBuffs = "EnableBuffs";
+      
+        public const string KnockbackMultiplier = "KnockbackMultiplier";
+        public const string KnockupAmount = "KnockupAmount";
+        public const string KnockbackFalloff = "KnockbackFalloff";
+        public const string MaxKnockbackSpeed = "MaxKnockbacSpeed";
+        public const string ComboTime = "ComboTime";
+
+
     }
 }

--- a/PvPModifier/Utilities/PvPConstants/ConfigConsts.cs
+++ b/PvPModifier/Utilities/PvPConstants/ConfigConsts.cs
@@ -30,7 +30,7 @@
         public const string KnockbackMultiplier = "KnockbackMultiplier";
         public const string KnockupAmount = "KnockupAmount";
         public const string KnockbackFalloff = "KnockbackFalloff";
-        public const string MaxKnockbackSpeed = "MaxKnockbacSpeed";
+        public const string MaxKnockbackSpeed = "MaxKnockbackSpeed";
         public const string ComboTime = "ComboTime";
 
 

--- a/PvPModifier/Utilities/PvPConstants/StringConsts.cs
+++ b/PvPModifier/Utilities/PvPConstants/StringConsts.cs
@@ -259,6 +259,39 @@
                     attribute = ConfigConsts.IframeTime;
                     return true;
 
+                case "knockbackmultiplier":
+                case "kbmultiplier":
+                case "multiplier":
+                case "kbmult":          
+                case "kbm":
+                    attribute = ConfigConsts.KnockbackMultiplier;
+                    return true;
+
+                case "knockupamount":
+                case "knockup":
+                case "kbup":
+                    attribute = ConfigConsts.KnockupAmount;
+                    return true;
+
+                case "knockbackfalloff" :
+                case "falloff":
+                case "foff":
+                case "kboff":
+                    attribute = ConfigConsts.KnockbackFalloff;
+                    return true;
+
+                case "maxknockbackspeed" :
+                case "maxkbspeed" :
+                case "mkbspeed" :
+                    attribute = ConfigConsts.MaxKnockbackSpeed;
+                    return true;
+
+                case "combotime":
+                case "ctime":
+                case "ct":
+                    attribute = ConfigConsts.ComboTime;
+                    return true;
+
                 default:
                     attribute = input;
                     return false;

--- a/PvPModifier/Variables/PvPPlayer.cs
+++ b/PvPModifier/Variables/PvPPlayer.cs
@@ -14,7 +14,7 @@ using PvPModifier.Utilities.PvPConstants;
 
 namespace PvPModifier.Variables {
     public class PvPPlayer : TSPlayer {
-        //make this not public later(hit time)
+
         DateTime _lastHit;
         DateTime _lastInventoryModified;
         public ProjectileTracker ProjTracker = new ProjectileTracker();
@@ -26,7 +26,7 @@ namespace PvPModifier.Variables {
         private int _medusaHitCount;
 
         private int _timesHit;    
-
+        
         public PvPPlayer(int index) : base(index) {
             _lastHit = DateTime.Now;
             _lastInventoryModified = DateTime.Now;


### PR DESCRIPTION
These changes aim to allow for greater flexibility when configuring custom knockback, by adding multiple fields:
-KnockbackMultiplier: Global Multiplier for all PvP knockback
-KnockupAmount: Makes knockback always throw you up by this set amount
-KnockbackFalloff: Exponential falloff based on combo 
-ComboTime: How fast a combo resets (milliseconds) 
-MaxKnockbackSpeed: Maximum speed at which knockback will stay additive
Also made knockback direction on projectiles based on the projectile itself instead of the player.