### PR TITLE
Knockback Changes

### DIFF
--- a/PvPModifier/Config.cs
+++ b/PvPModifier/Config.cs
@@ -31,6 +31,12 @@ namespace PvPModifier {
 
         public bool EnableBuffs;
 
+        public double KnockbackMultiplier;
+        public double KnockupAmount;
+        public double KnockbackFalloff;
+        public double MaxKnockbackSpeed;
+        public uint ComboTime;
+
         public bool FirstConfigGeneration = true;
 
         /// <summary>
@@ -78,6 +84,12 @@ namespace PvPModifier {
                 LoseVortexOnHit = false;
 
                 EnableBuffs = true;
+
+                KnockbackMultiplier = 1.0;
+                KnockupAmount = 1.0;
+                KnockbackFalloff = 0.5;
+                MaxKnockbackSpeed = 30.0;
+                ComboTime = 500;
 
                 FirstConfigGeneration = false;
                 return true;

--- a/PvPModifier/Network/Events/PlayerEvents.cs
+++ b/PvPModifier/Network/Events/PlayerEvents.cs
@@ -88,11 +88,24 @@ namespace PvPModifier.Network.Events {
 
             if (PvPModifier.Config.EnableKnockback) {
                 int direction = e.HitDirection;
-                if (!e.Target.TPlayer.noKnockback || PvPModifier.Config.ForceCustomKnockback) {
-                    e.Target.KnockBack(e.Weapon.GetKnockback(e.Attacker),
-                        e.Attacker.AngleFrom(e.Target.TPlayer.position),
-                        e.Target.IsLeftFrom(e.Attacker.TPlayer.position) ? -direction : direction);
+                double angle;
+                if (e.PlayerHitReason.SourceProjectileIndex != -1) {
+                    //If the projectile doesn't have a velocity(or is segmented like vilethorn/nettle burst we must use another method to calculate angle, this fixes projectiles like vilethorn/proximity mines
+                    if (e.Projectile.velocity.Length() > 0 && e.Projectile.type != 7 && e.Projectile.type != 8 && e.Projectile.type != 150 && e.Projectile.type != 151 && e.Projectile.type != 152 && e.Projectile.type != 493 && e.Projectile.type != 494) {
+                        angle = System.Math.Atan2(e.Projectile.velocity.Y, e.Projectile.velocity.X);
+                    }
+                    else {              
+                        angle = System.Math.Atan2(e.Attacker.TPlayer.position.Y - e.Projectile.position.Y, e.Attacker.TPlayer.position.X - e.Projectile.position.X);
+                    }
+                    direction = e.Target.IsLeftFrom(e.Projectile.position) ? -direction : direction;
                 }
+                else {
+                    angle = e.Attacker.AngleFrom(e.Target.TPlayer.position);
+                    direction = e.Target.IsLeftFrom(e.Attacker.TPlayer.position) ? -direction : direction;
+                }
+                e.Target.KnockBack(e.Weapon.GetKnockback(e.Attacker),
+                   angle,
+                   direction);
                 e.HitDirection = 0;
             }
 

--- a/PvPModifier/Utilities/PvPConstants/ConfigConsts.cs
+++ b/PvPModifier/Utilities/PvPConstants/ConfigConsts.cs
@@ -29,5 +29,11 @@
         public const string LoseVortexOnHit = "LoseVortexOnHit";
 
         public const string EnableBuffs = "EnableBuffs";
+
+        public const string KnockbackMultiplier = "KnockbackMultiplier";
+        public const string KnockupAmount = "KnockupAmount";
+        public const string KnockbackFalloff = "KnockbackFalloff";
+        public const string MaxKnockbackSpeed = "MaxKnockbackSpeed";
+        public const string ComboTime = "ComboTime";
     }
 }

--- a/PvPModifier/Utilities/PvPConstants/StringConsts.cs
+++ b/PvPModifier/Utilities/PvPConstants/StringConsts.cs
@@ -327,6 +327,39 @@
                     attribute = ConfigConsts.LoseVortexOnHit;
                     return true;
 
+                case "knockbackmultiplier":
+                case "kbmultiplier":
+                case "multiplier":
+                case "kbmult":
+                case "kbm":
+                    attribute = ConfigConsts.KnockbackMultiplier;
+                    return true;
+
+                case "knockupamount":
+                case "knockup":
+                case "kbup":
+                    attribute = ConfigConsts.KnockupAmount;
+                    return true;
+
+                case "knockbackfalloff":
+                case "falloff":
+                case "foff":
+                case "kboff":
+                    attribute = ConfigConsts.KnockbackFalloff;
+                    return true;
+
+                case "maxknockbackspeed":
+                case "maxkbspeed":
+                case "mkbspeed":
+                    attribute = ConfigConsts.MaxKnockbackSpeed;
+                    return true;
+
+                case "combotime":
+                case "ctime":
+                case "ct":
+                    attribute = ConfigConsts.ComboTime;
+                    return true;
+
                 default:
                     attribute = input;
                     return false;


### PR DESCRIPTION
These changes aim to allow for greater flexibility when configuring custom knockback, by adding multiple fields:
-KnockbackMultiplier: Global Multiplier for all PvP knockback
-KnockupAmount: Makes knockback always throw you up by this set amount
-KnockbackFalloff: Exponential falloff based on combo
-ComboTime: How fast a combo resets (milliseconds)
-MaxKnockbackSpeed: Maximum speed at which knockback will stay additive
Also made knockback direction on projectiles based on the projectile itself instead of the player.